### PR TITLE
Use KeepAliveIsolateSOCKSAuth against TB fingerprinting

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 3.9.6
 
 Package: anon-gw-anonymizer-config
 Architecture: all
-Depends: anon-shared-helper-scripts, tor, sudo, anon-base-files,
+Depends: anon-shared-helper-scripts, tor (>= 0.2.7.3), sudo, anon-base-files,
  ${misc:Depends}
 Recommends: control-port-filter-python
 Provides: ${diverted-files}

--- a/usr/share/tor/tor-service-defaults-torrc.anondist
+++ b/usr/share/tor/tor-service-defaults-torrc.anondist
@@ -370,7 +370,7 @@ SocksPort 10.152.152.10:9125
 ## performance loss, too much load on Tor network and not secure.
 ## Ticket https://trac.torproject.org/projects/tor/ticket/3455
 ## is the right way to solve this issue. Waiting for upstream.
-SocksPort 10.152.152.10:9150
+SocksPort 10.152.152.10:9150 IPv6Traffic PreferIPv6 KeepAliveIsolateSOCKSAuth
 
 ## Tor Messenger's default port
 ## This port gets used if someone uses the default Tor Messenger.
@@ -490,7 +490,7 @@ SocksPort 127.0.0.1:9122
 SocksPort 127.0.0.1:9123
 SocksPort 127.0.0.1:9124
 SocksPort 127.0.0.1:9125
-SocksPort 127.0.0.1:9150
+SocksPort 127.0.0.1:9150 IPv6Traffic PreferIPv6 KeepAliveIsolateSOCKSAuth
 
 #####################################################
 ## End of /usr/share/tor/tor-service-defaults-torrc #


### PR DESCRIPTION
Now that tor 0.2.7.5 is stable at last and has landed in the
torproject.org debian repo, use KeepAliveIsolateSOCKSAuth (available
since 0.2.7.3-rc) for port 9150 so Tor-Browser-with-upstream-tor is no
longer trivially fingerprintable.