### PR TITLE
Update tor-service-defaults-torrc.anondist

### DIFF
--- a/usr/share/tor/tor-service-defaults-torrc.anondist
+++ b/usr/share/tor/tor-service-defaults-torrc.anondist
@@ -377,7 +377,7 @@ SocksPort 10.152.152.10:9150 IPv6Traffic PreferIPv6 KeepAliveIsolateSOCKSAuth
 ## (rinetd runs on Workstation and forwards connections from
 ##  127.0.0.1:9152 to 10.152.152.10:9152 [as part of the
 ## anon-ws-disable-stacked-tor package].)
-SocksPort 10.152.152.10:9152
+SocksPort 10.152.152.10:9152 IsolateDestAddr IsolateDestPort
 
 ##+# #OptionalFeatureNr.4# More Socks Ports.
 ## Custom Ports #1:


### PR DESCRIPTION
Provide stream isolation for multiple identities / connections in Tor Messenger.
Similar to Instant Messenger SocksPort 9103.