### PR TITLE
use a better URL to bridge

### DIFF
--- a/etc/tor/torrc.examples
+++ b/etc/tor/torrc.examples
@@ -37,7 +37,7 @@ Bridges
     Finding Public Bridges
     ----------------------
 
-      https://bridges.torproject.org/bridges
+      https://bridges.torproject.org/options
 
       If you can not reach the URL, send an email (from a
       gmail.com or yahoo.com account only) to


### PR DESCRIPTION
JasonJAyalaP wrote in https://phabricator.whonix.org/T684

> torrc.examples shows how to add bridges (but should obfs4 have the "managed" line?). It gives a link, but there is a better link:
> https://bridges.torproject.org/options

Changed to use that link in this pull request.