### PR TITLE
Change the AppArmor rules for anon-connection-wizard

### DIFF
--- a/etc/apparmor.d/local/system_tor.anondist
+++ b/etc/apparmor.d/local/system_tor.anondist
@@ -26,12 +26,12 @@
 ## versus no AppArmor at all.
 
   ## anon-connection-wizard
-  /etc/ rw,
-  /etc/torrc.d/ r,
-  /etc/torrc.d/* r,
+  /etc/ r,
+  /etc/torrc.d/ rw,
+  /etc/torrc.d/* rw,
 
-  /usr/local/etc/torrc.d/ r,
-  /usr/local/etc/torrc.d/* r,
+  /usr/local/etc/torrc.d/ rw,
+  /usr/local/etc/torrc.d/* rw,
 
   ## obfsproxy
   /usr/local/lib/python*/** r,


### PR DESCRIPTION
One thing I am not quiet sure:
```

-  /usr/local/etc/torrc.d/ r,
-  /usr/local/etc/torrc.d/* r,
+  /usr/local/etc/torrc.d/ rw,
+  /usr/local/etc/torrc.d/* rw,
```

It seems we should give the write permissions, correct?