### PR TITLE
 Support verbose parsing and smart suggestion for anon-verify 

### DIFF
--- a/etc/apparmor.d/local/system_tor.anondist
+++ b/etc/apparmor.d/local/system_tor.anondist
@@ -58,6 +58,6 @@
   /proc/*/mounts r,
 
   ## snowflake
-  /usr/bin/snowflake-client rix,
+  /usr/bin/snowflake-client ix,
 
 ## End Tor Local AppArmor Profile for Anonymity Distributions

--- a/usr/bin/anon-verify
+++ b/usr/bin/anon-verify
@@ -98,7 +98,7 @@ $start_menu_instructions_system_first_part Terminal
 	f_torrc="${BASH_REMATCH[2]}"
     fi
 
-    parser $default_torrc $f_torrc
+    parser "$default_torrc" "$f_torrc"
 
     echo "====================================================================="
     used_torrc_files

--- a/usr/bin/anon-verify
+++ b/usr/bin/anon-verify
@@ -50,9 +50,6 @@ $tor_verify_config_output
 "
     fi
 
-    ## TODO: grep the invalid option for user and specify which file
-    ## is corrupted for better fixing suggestion
-
     ## TODO: $anon_verify_report_html is used by whonixcheck
     ## we need to find a way to merge it with $anon_verify_report
     tor_verify_config_output_html="$(/usr/lib/msgcollector/br_add "$tor_verify_config_output")"
@@ -86,7 +83,8 @@ $start_menu_instructions_system_first_part Terminal
     ## print out the report
     echo "$anon_verify_report"
 
-    ## print out info by torrc-parser
+    ## torrc-parser will grep the invalid option for user and specify
+    ## which file is corrupted for better fixing suggestion
     source /usr/lib/anon-gw-anonymizer-config/torrc-parser
 
     ## extract default_torrc file and -f torrc file
@@ -98,13 +96,19 @@ $start_menu_instructions_system_first_part Terminal
 	f_torrc="${BASH_REMATCH[2]}"
     fi
 
+    # call parser() to parse torrc files, arguments order matters
     parser "$default_torrc" "$f_torrc"
 
     echo "====================================================================="
+    echo "================= Used Tor Configuration Files  ====================="
+    echo "====================================================================="
     used_torrc_files
 
+    ## extract the unknown option complained by Tor
     if [[ "$tor_verify_config_output" =~ (Unknown option \')([^\']*) ]]; then
 	echo "====================================================================="
+        echo "================== Detailed Suggested Solution  ====================="
+        echo "====================================================================="
 	unknown_option_specifier "${BASH_REMATCH[2]}"
     fi
 
@@ -113,7 +117,7 @@ $start_menu_instructions_system_first_part Terminal
     ## and only use it with anon-verify -v
     ## we may even use anon-verify -vv to show lines starts with # also
     echo "====================================================================="
-    echo "============ Verbose Tor Configuration Parsing  ====================="
+    echo "=============== Verbose Tor Configuration Parsing  =================="
     echo "====================================================================="
     parsing_order_verbose
 

--- a/usr/bin/anon-verify
+++ b/usr/bin/anon-verify
@@ -47,13 +47,7 @@ $tor_verify_config_output_concise
 
 Tor full reports:
 $tor_verify_config_output
-=====================================================================
-To try to fix this, please open your Tor config file in Terminal:
-sudo nano /usr/local/etc/torrc.d/50_user.conf
-
-Please restart Tor after fixing this error in Terminal:
-sudo service tor@default restart
-====================================================================="
+"
     fi
 
     ## TODO: grep the invalid option for user and specify which file
@@ -91,6 +85,40 @@ $start_menu_instructions_system_first_part Terminal
 
     ## print out the report
     echo "$anon_verify_report"
+
+    ## print out info by torrc-parser
+    source /usr/lib/anon-gw-anonymizer-config/torrc-parser
+
+    ## extract default_torrc file and -f torrc file
+    if [[ "$tor_start_command" =~ (--defaults-torrc )([^ ]*) ]]; then
+	default_torrc="${BASH_REMATCH[2]}"
+    fi
+
+    if [[ "$tor_start_command" =~ (-f )([^ ]*) ]]; then
+	f_torrc="${BASH_REMATCH[2]}"
+    fi
+
+    parser $default_torrc $f_torrc
+
+    echo "====================================================================="
+    used_torrc_files
+
+    if [[ "$tor_verify_config_output" =~ (Unknown option \')([^\']*) ]]; then
+	echo "====================================================================="
+	unknown_option_specifier "${BASH_REMATCH[2]}"
+    fi
+    echo "====================================================================="
+
+
+    ## TODO: parsing_order_verbose creates a very long ouput which is
+    ## not user-friendly. Therefore, we need to disable it by default
+    ## and only use it with anon-verify -v
+    ## we may even use anon-verify -vv to show lines starts with # also
+    echo "====================================================================="
+    echo "============ Verbose Tor Configuration Parsing  ====================="
+    echo "====================================================================="
+    parsing_order_verbose
+
 }
 
 get_tor_start_command

--- a/usr/bin/anon-verify
+++ b/usr/bin/anon-verify
@@ -107,8 +107,6 @@ $start_menu_instructions_system_first_part Terminal
 	echo "====================================================================="
 	unknown_option_specifier "${BASH_REMATCH[2]}"
     fi
-    echo "====================================================================="
-
 
     ## TODO: parsing_order_verbose creates a very long ouput which is
     ## not user-friendly. Therefore, we need to disable it by default
@@ -119,6 +117,7 @@ $start_menu_instructions_system_first_part Terminal
     echo "====================================================================="
     parsing_order_verbose
 
+    echo "====================================================================="
 }
 
 get_tor_start_command

--- a/usr/lib/anon-gw-anonymizer-config/make-sure-torrc-exist
+++ b/usr/lib/anon-gw-anonymizer-config/make-sure-torrc-exist
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ## Copyright (C) 2018 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## Copyright (C) 2018 Iry Koon <iry@riseup.net>
 ## See the file COPYING for copying conditions.
 
 if [ ! -d /usr/local/etc/torrc.d ]; then

--- a/usr/lib/anon-gw-anonymizer-config/torrc-parser
+++ b/usr/lib/anon-gw-anonymizer-config/torrc-parser
@@ -11,24 +11,24 @@ temp_verbose_torrc=$(mktemp)
 declare -a torrc_files
 
 function parser() {
-    for abs_path in $@; do
+    for abs_path in "$@"; do
 	local abs="$abs_path"
-	echo "===> Parsing $abs_path" >> $temp_verbose_torrc
+	echo "===> Parsing $abs_path" >> "$temp_verbose_torrc"
 	if [[ -f  "$abs_path" ]]; then
 	    torrc_files+=("$abs_path")
-	    local file_content="$(cat "$abs")"
+	    local file_content
+            file_content="$(cat "$abs")"
 	    IFS=$'\n'
 	    for line in $file_content; do
-		echo "$line" >> $temp_verbose_torrc
+		echo "$line" >> "$temp_verbose_torrc"
 		if [[ "$line" =~ ^%include ]]; then
-                    parser $(echo "$line" | awk '{print $2;}')
+                    parser "$(echo "$line" | awk '{print $2;}')"
 		fi
 	    done
-	else if [[ -d "$abs_path" ]]; then
-		 parser "$(find $abs_path -mindepth 1 | sort -g)"
-             fi
-	fi
-	echo "===> Done parsing $abs" >> $temp_verbose_torrc
+	elif [[ -d "$abs_path" ]]; then
+		 parser "$(find "$abs_path" -mindepth 1 | sort -g)"
+        fi
+	echo "===> Done parsing $abs" >> "$temp_verbose_torrc"
     done
 }
 
@@ -45,7 +45,7 @@ function used_torrc_files(){
 function unknown_option_specifier(){
     for unknown_option in "$@"; do
 	echo "The following files contain unkown option '$unknown_option': "
-	grep -iHn --color "^$unknown_option" ${torrc_files[@]}
+	grep -iHn --color "^$unknown_option" "${torrc_files[@]}"
 	echo "Please modify these files to fix the problem."
     done
 }

--- a/usr/lib/anon-gw-anonymizer-config/torrc-parser
+++ b/usr/lib/anon-gw-anonymizer-config/torrc-parser
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#set -ex
+
+temp_verbose_torrc=$(mktemp)
+
+declare -a torrc_files
+
+function parser() {
+    for abs_path in $@; do
+	local abs="$abs_path"
+	echo "===> Parsing $abs_path" >> $temp_verbose_torrc
+	if [[ -f  "$abs_path" ]]; then
+	    torrc_files+=("$abs_path")
+	    local file_content="$(cat "$abs")"
+	    IFS=$'\n'
+	    for line in $file_content; do
+		echo "$line" >> $temp_verbose_torrc
+		if [[ "$line" =~ ^%include ]]; then
+                    parser $(echo "$line" | awk '{print $2;}')
+		fi
+	    done
+	else if [[ -d "$abs_path" ]]; then
+		 parser "$(find $abs_path -mindepth 1 | sort -g)"
+             fi
+	fi
+	echo "===> Done parsing $abs" >> $temp_verbose_torrc
+    done
+}
+
+function parsing_order_verbose(){
+    echo "The Tor configuration files are parsed in such order: "
+    cat "$temp_verbose_torrc"
+}
+
+function used_torrc_files(){
+    echo "${#torrc_files[@]} files are used as Tor configuration files: "
+    echo "${torrc_files[@]}"
+}
+
+function unknown_option_specifier(){
+    for unknown_option in "$@"; do
+	echo "The following files contain unkown option '$unknown_option': "
+	grep -iHn --color "^$unknown_option" ${torrc_files[@]}
+	echo "Please modify these files to fix the problem."
+    done
+}
+
+#parser $@
+#parsing_order_verbose
+#used_torrc_files
+#unknown_option_specifier "bridge" "control"

--- a/usr/lib/anon-gw-anonymizer-config/torrc-parser
+++ b/usr/lib/anon-gw-anonymizer-config/torrc-parser
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+## Copyright (C) 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## Copyright (C) 2018 Iry Koon <iry@riseup.net>
+## See the file COPYING for copying conditions.
+
 #set -ex
 
 temp_verbose_torrc=$(mktemp)


### PR DESCRIPTION
The configuration file parsing for system Tor is complex. It is hard
for a daily user to figure out what exact command is used by systemd
to start Tor. Moreover, it can be overwhelming for a human being to
follow the logic of Tor configuration parsing since the %include line
can appear any where in a file and the included path can be either a
directory or a file.

Therefore, anon-verify is now upgraded to free user from these
overwhelming work by support verbose parsing and smart suggestion.

For the verbose parsing, anon-verify will automatically extract the torrc
files used in systemd that starts Tor. And then, it will show user the
parsing of torrc files step by step, following the exact same logic
Tor used.

In terms of the smart suggestion, anon-verify will try to offer an
specific and useful suggestion when there is something wrong with the
Tor configuration. For example, when a wrong option is included by
user, Tor will simply complain:

```
[warn] Failed to parse/validate config: Unknown option 'dsafklj'. Failing.
```

But anon-verify will tell user:

```
The following files contain unkown option 'dsafklj':
/etc/tor/torrc:5:dsafklj
Please modify these files to fix the problem.
```

anon-verify can also tell users how many and which files have been
used the Tor configuration files, making them suddenly realize if they
have included any file they don't want to use:

```
7 files are used as Tor configuration files:
/usr/share/tor/tor-service-defaults-torrc /etc/tor/torrc /etc/torrc.d/95_whonix.conf /usr/local/etc/torrc.d/40_anon_connection_wizard.conf /usr/local/etc/torrc.d/40_anon_connection_wizard.conf~ /usr/local/etc/torrc.d/50_user.conf /usr/local/etc/torrc.d/50_user.conf~
```